### PR TITLE
ci: workflows can now be started manually, but only in the "main" and "dev" branches

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -173,7 +173,7 @@ jobs:
           mv release/linux-ia32-unpacked ${{env.BUILD_DIR_TEMP}}/
 
       - name: Upload artifact
-        if: ${{ inputs.artifact_upload == true }}
+        if: ${{ inputs.artifact_upload == true || startsWith(github.ref, 'refs/heads/main')}}
         uses: actions/upload-artifact@v3
         with:
           name: Anilibrix Plus

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -21,6 +21,13 @@ on:
       - '.github/assets/**'
       - '.github/ISSUE_TEMPLATE/**'
       - 'updater/README.md'
+  
+  workflow_dispatch:
+    inputs:
+      artifact_upload:
+        description: 'Artifact uploading'
+        required: false
+        type: boolean
 
 env:
   ENV_EXAMPLE_FILE: .env.example
@@ -30,6 +37,8 @@ env:
 
 jobs:
   release:
+    if: ${{ startsWith(github.ref, 'refs/heads/main') || startsWith(github.ref, 'refs/heads/dev') }}
+
     permissions: write-all
     runs-on: ${{ matrix.os }}
 
@@ -164,12 +173,14 @@ jobs:
           mv release/linux-ia32-unpacked ${{env.BUILD_DIR_TEMP}}/
 
       - name: Upload artifact
+        if: ${{ inputs.artifact_upload == true }}
         uses: actions/upload-artifact@v3
         with:
           name: Anilibrix Plus
           path: ${{env.BUILD_DIR_TEMP}}/*
 
       - name: Archiving binary files
+        if: ${{ startsWith(github.ref, 'refs/heads/main') }}
         run: |
           cd ${{env.BUILD_DIR_TEMP}}
           zip -r linux-arm64-unpacked.zip linux-arm64-unpacked

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -22,12 +22,21 @@ on:
       - '.github/ISSUE_TEMPLATE/**'
       - 'updater/README.md'
 
+  workflow_dispatch:
+    inputs:
+      artifact_upload:
+        description: 'Artifact uploading'
+        required: false
+        type: boolean
+
 env:
   ENV_EXAMPLE_FILE: .env.example
   PACKAGE_FILE: package.json
 
 jobs:
   release:
+    if: ${{ startsWith(github.ref, 'refs/heads/main') || startsWith(github.ref, 'refs/heads/dev') }}
+
     permissions: write-all
     runs-on: ${{ matrix.os }}
 
@@ -120,6 +129,7 @@ jobs:
         run: npm run release:mac
 
       - name: Upload artifact
+        if: ${{ inputs.artifact_upload == true }}
         uses: actions/upload-artifact@v3
         with:
           name: Anilibrix Plus

--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -129,7 +129,7 @@ jobs:
         run: npm run release:mac
 
       - name: Upload artifact
-        if: ${{ inputs.artifact_upload == true }}
+        if: ${{ inputs.artifact_upload == true || startsWith(github.ref, 'refs/heads/main')}}
         uses: actions/upload-artifact@v3
         with:
           name: Anilibrix Plus

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -168,7 +168,7 @@ jobs:
           mv release/win-ia32-unpacked ${{env.BUILD_DIR_TEMP}}/
 
       - name: Upload artifact
-        if: ${{ inputs.artifact_upload == true }}
+        if: ${{ inputs.artifact_upload == true || startsWith(github.ref, 'refs/heads/main')}}
         uses: actions/upload-artifact@v3
         with:
           name: Anilibrix Plus

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -21,6 +21,13 @@ on:
       - '.github/assets/**'
       - '.github/ISSUE_TEMPLATE/**'
       - 'updater/README.md'
+    
+  workflow_dispatch:
+    inputs:
+      artifact_upload:
+        description: 'Artifact uploading'
+        required: false
+        type: boolean
 
 env:
   ENV_EXAMPLE_FILE: .env.example
@@ -30,6 +37,8 @@ env:
 
 jobs:
   release:
+    if: ${{ startsWith(github.ref, 'refs/heads/main') || startsWith(github.ref, 'refs/heads/dev') }}
+
     permissions: write-all
     runs-on: ${{ matrix.os }}
 
@@ -159,12 +168,14 @@ jobs:
           mv release/win-ia32-unpacked ${{env.BUILD_DIR_TEMP}}/
 
       - name: Upload artifact
+        if: ${{ inputs.artifact_upload == true }}
         uses: actions/upload-artifact@v3
         with:
           name: Anilibrix Plus
           path: ${{env.BUILD_DIR_TEMP}}/*
 
       - name: Archiving binary files
+        if: ${{ startsWith(github.ref, 'refs/heads/main') }}
         shell: powershell
         run: |
           cd ${{env.BUILD_DIR_TEMP}}


### PR DESCRIPTION
This was done so that the application could be built, offloaded into artifacts, and tested before submitting the code to the release branch of "main".